### PR TITLE
docs: add need help section after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 
 **NOTE:** Please make sure to keep your API keys and configuration values secure and do not expose them publicly.
 
+### :raising_hand: Need Help?
+
+If you run into issues during installation or setup:
+
+- **GitHub Discussions** — [Open a Q&A discussion](https://github.com/sanidhyy/imaginify/discussions/new?category=q-a) for setup and troubleshooting help.
+- **Email** — [sanidhyyy@gmail.com](mailto:sanidhyyy@gmail.com)
+- **Discord** — `sanidhyy`
+
 ## :camera: Screenshots
 
 ![Modern UI/UX](/.github/images/img1.png "Modern UI/UX")

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If you run into issues during installation or setup:
 
 - **GitHub Discussions** — [Open a Q&A discussion](https://github.com/sanidhyy/imaginify/discussions/new?category=q-a) for setup and troubleshooting help.
 - **Email** — [sanidhyyy@gmail.com](mailto:sanidhyyy@gmail.com)
-- **Discord** — `sanidhyy`
+- **Discord** — `@sanidhyy`
 
 ## :camera: Screenshots
 


### PR DESCRIPTION
## Summary
- Adds a **Need Help?** section after the installation/setup instructions
- Includes GitHub Discussions (Q&A), email, and Discord contact options

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm help section appears after setup instructions
